### PR TITLE
Copy some org text properties so `g` and `l` work after changes

### DIFF
--- a/org-clock-convenience.el
+++ b/org-clock-convenience.el
@@ -217,9 +217,16 @@ associated org agenda file."
 									   org-clock-convenience-tr-re
 									   org-clock-convenience-tr-fields))))
       (org-clock-convenience-goto-agenda-tr-field timefield)
-      (let ((inhibit-read-only t))
+      (let* ((inhibit-read-only t)
+             (props (text-properties-at (point))))
 	(delete-char (length updated-time))
-	(insert (propertize updated-time 'face 'secondary-selection))))
+	(insert (propertize updated-time
+                            'face 'secondary-selection
+                            'org-redo-cmd (plist-get props 'org-redo-cmd)
+                            'org-agenda-type (plist-get props 'org-agenda-type)
+                            'org-last-args (plist-get props 'org-last-args)
+                            'org-series-cmd (plist-get props 'org-series-cmd)
+                            'org-series-redo-cmd (plist-get props 'org-series-redo-cmd)))))
     (goto-char pos)
     )
   )


### PR DESCRIPTION
----

Without this patch, you have to move away from the timestamp before `g`/`l` work