### PR TITLE
A more permissive time range regexp for custom prefix-format

### DIFF
--- a/org-clock-convenience.el
+++ b/org-clock-convenience.el
@@ -40,13 +40,6 @@
 (require 'org-element)
 (require 'cl-lib)
 
-;; save-mark-and-excursion in Emacs 25 works like save-excursion did before
-(eval-when-compile
-  (when (< emacs-major-version 25)
-    (defmacro save-mark-and-excursion (&rest body)
-      `(save-excursion ,@body))))
-
-
 (defvar org-clock-convenience-clocked-agenda-re
   "\\(\\([ \t012][0-9]\\):\\([0-5][0-9]\\)\\)\\(?:-\\(\\([ 012]?[0-9]\\):\\([0-5][0-9]\\)\\)\\)"
   "Regexp of a clocked time range log line in the Org agenda buffer.")

--- a/org-clock-convenience.el
+++ b/org-clock-convenience.el
@@ -79,7 +79,7 @@ The fieldnames are given as a list of symbols in FNAMES.  An error message
 for the case of the regexp not matching can be passed in ERRMSG."
   (let ((idx (or (cl-position fieldname fnames)
 		 (error "No such field name: %s" fieldname))))
-    (unless (looking-at re)
+    (unless (org-in-regexp re)
       (error (or errmsg
 		 "Error: regexp for analyzing fields does not match here")))
     (goto-char (match-beginning (1+ idx)))))
@@ -108,8 +108,7 @@ names of the smaller subpatterns).  ERRMSG allows specifying an
 error message if RE is not matching."
   (save-mark-and-excursion
     (goto-char point)
-    (beginning-of-line)
-    (cl-assert (looking-at re) nil
+    (cl-assert (org-in-regexp re) nil
 	       (or errmsg
 		   "Error: regexp for analyzing fields does not match here")))
   (cl-loop
@@ -132,7 +131,6 @@ in `org-clock-convenience-tr-fields'."
 (defun org-clock-convenience-goto-agenda-tr-field (fieldname)
   "Move cursor to the FIELDNAME of a agenda view clocked log line."
   (cl-assert (eq major-mode 'org-agenda-mode) nil "Error: Not in agenda mode")
-  (beginning-of-line)
   (org-clock-convenience-goto-re-field fieldname org-clock-convenience-clocked-agenda-re
 				       org-clock-convenience-clocked-agenda-fields
 				       "Error: not on a clocked time log line"))

--- a/org-clock-convenience.el
+++ b/org-clock-convenience.el
@@ -342,19 +342,16 @@ from anywhere within a valid clocked time range line."
   (interactive)
   (cl-assert (eq major-mode 'org-agenda-mode) nil "Error: Not in agenda mode")
   (save-excursion
-    (beginning-of-line)
-    (cl-assert (looking-at org-clock-convenience-clocked-agenda-re) nil
-	       "Error: Not on a clocked time range line")
+    (cl-assert (org-in-regexp org-clock-convenience-clocked-agenda-re) nil
+               "Error: Not on a clocked time range line")
     (org-clock-convenience-goto-re-field 'd1-time
-					 org-clock-convenience-clocked-agenda-re
-					 org-clock-convenience-clocked-agenda-fields)
+                                         org-clock-convenience-clocked-agenda-re
+                                         org-clock-convenience-clocked-agenda-fields)
     (org-clock-convenience-fill-gap)
-    (beginning-of-line)
     (org-clock-convenience-goto-re-field 'd2-time
-					 org-clock-convenience-clocked-agenda-re
-					 org-clock-convenience-clocked-agenda-fields)
-    (org-clock-convenience-fill-gap))
-  )
+                                         org-clock-convenience-clocked-agenda-re
+                                         org-clock-convenience-clocked-agenda-fields)
+    (org-clock-convenience-fill-gap)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/org-clock-convenience.el
+++ b/org-clock-convenience.el
@@ -48,11 +48,11 @@
 
 
 (defvar org-clock-convenience-clocked-agenda-re
-  "^ +\\([^:]+\\):[[:space:]]*\\(\\([ \t012][0-9]\\):\\([0-5][0-9]\\)\\)\\(?:-\\(\\([ 012][0-9]\\):\\([0-5][0-9]\\)\\)\\|.*\\)?[[:space:]]+Clocked:[[:space:]]+\\(([0-9]+:[0-5][0-9])\\|(-)\\)"
+  "\\(\\([ \t012][0-9]\\):\\([0-5][0-9]\\)\\)\\(?:-\\(\\([ 012]?[0-9]\\):\\([0-5][0-9]\\)\\)\\)"
   "Regexp of a clocked time range log line in the Org agenda buffer.")
 
 (defvar org-clock-convenience-clocked-agenda-fields
-  '(filename d1-time d1-hours d1-minutes d2-time d2-hours d2-minutes duration)
+  '(d1-time d1-hours d1-minutes d2-time d2-hours d2-minutes)
   "Field names corresponding to submatches of `org-clock-convenience-clocked-agenda-re'.")
 
 (defvar org-clock-convenience-tr-re


### PR DESCRIPTION
Title says it all, this is to address the #10 issue. As @dfeich has noted, it's the regexp that causes the issue.

Now, instead of going to the beginning of the line and match the whole line which isn't reliable when effort estimate is also on the line, we use `org-in-regexp` to see if point is at a time range.

So now the minimum requirement for a custom `org-agenda-prefix-format` is just to have `%t`.