### PR TITLE
fix: make `org-clock-convenience-fill-gap` compatible with org 9.6

### DIFF
--- a/org-clock-convenience.el
+++ b/org-clock-convenience.el
@@ -326,8 +326,10 @@ the current agenda buffer."
 	  (let ((time (current-time)))
 	    (setq updated-ts (format-time-string
 			      (concat "["
-				      (substring (cdr org-time-stamp-formats)
-						 1 -1)
+				          (if (version<= org-version "9.5")
+                              (substring (cdr org-time-stamp-formats)
+						                 1 -1)
+                            (cdr org-time-stamp-formats))
 				      "]")
 			      time)
 		  updated-time (format-time-string "%H:%M" time)))


### PR DESCRIPTION
Since org 9.6, leading =<= and trailing =>= in the default values of `org-time-stamp-formats` and `org-time-stamp-custom-formats` are stripped.